### PR TITLE
Added default export to CommonJS variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,3 +205,5 @@ if (require('has-symbols')() || require('has-symbols/shams')()) {
 		};
 	}
 }
+
+module.exports['default'] = module.exports;

--- a/node.js
+++ b/node.js
@@ -10,3 +10,5 @@ module.exports = function getIterator(iterable) {
 		return iterable[$iterator]();
 	}
 };
+
+module.exports['default'] = module.exports;


### PR DESCRIPTION
I currently writing a TypeScript definition for this package on DefinitelyTyped/DefinitelyTyped#51389. Adding a default export to CommonJS variants could avoid confusion to the users.